### PR TITLE
Update Dockerfile

### DIFF
--- a/internals/docker/Dockerfile
+++ b/internals/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:10-jessie-slim
 
-RUN apt-get update && apt-get install libpng12-0 bzip2
+RUN apt-get update && apt-get install libpng12-0 bzip2 -y
 
 # Create app directory
 WORKDIR /usr/src/app


### PR DESCRIPTION
Running Docker-Compose fails without the `-y` flag:
```
After this operation, 395 kB of additional disk space will be used.
Do you want to continue? [Y/n] Abort.
```